### PR TITLE
fix: Padding for 'How it works' fixes

### DIFF
--- a/src/components/Features.tsx
+++ b/src/components/Features.tsx
@@ -145,7 +145,7 @@ export function Features() {
     <section
       id='how-it-works'
       aria-label='Features for simplifying everyday business tasks'
-      className='bg-white pt-10 pb-14 sm:pb-20 sm:pt-32 lg:pb-32'
+      className='bg-white pt-10 sm:pb-20 sm:pt-32 lg:pb-32'
     >
       <Container>
         <div className='mx-auto max-w-2xl md:text-center'>

--- a/src/components/Features.tsx
+++ b/src/components/Features.tsx
@@ -145,7 +145,7 @@ export function Features() {
     <section
       id='how-it-works'
       aria-label='Features for simplifying everyday business tasks'
-      className='bg-white pt-10 pb-4 sm:pb-20 sm:pt-32 lg:pb-32'
+      className='bg-white pt-10 pb-14 sm:pb-20 sm:pt-32 lg:pb-32'
     >
       <Container>
         <div className='mx-auto max-w-2xl md:text-center'>

--- a/src/components/Features.tsx
+++ b/src/components/Features.tsx
@@ -98,7 +98,7 @@ function Feature({ feature, isActive, className, ...props }: props) {
 
 function FeaturesMobile() {
   return (
-    <div className='-mx-4 mt-20 flex flex-col gap-y-10 overflow-hidden px-4 sm:-mx-6 sm:px-6 lg:hidden'>
+    <div className='-mx-4 mt-10 flex flex-col gap-y-10 overflow-hidden px-4 sm:-mx-6 sm:px-6 lg:hidden'>
       {features.map(feature => (
         <div key={feature.name}>
           <Feature feature={feature} className='mx-auto max-w-2xl' isActive />

--- a/src/components/Features.tsx
+++ b/src/components/Features.tsx
@@ -145,7 +145,7 @@ export function Features() {
     <section
       id='how-it-works'
       aria-label='Features for simplifying everyday business tasks'
-      className='bg-white pt-20 pb-14 sm:pb-20 sm:pt-32 lg:pb-32'
+      className='bg-white pt-10 pb-4 sm:pb-20 sm:pt-32 lg:pb-32'
     >
       <Container>
         <div className='mx-auto max-w-2xl md:text-center'>


### PR DESCRIPTION
### 🛠️ Fixes Issue
Closes #210 
<!-- If your PR fixes an open issue, use `Closes #101` to link your PR with the issue -->
<!-- Here, #101 stands for the issue number you are fixing -->
<!-- Example: Closes #31 -->

### ➕ Changes Introduced
Padding and margin fix on the "How it works" section (Features.tsx file). 

<!-- List all the changes introduced in your PR -->

### 📄 Note To Reviewers

<!-- Add notes to reviewers if applicable -->

### 📷 Screenshots
Before (pb-14)
<img width="519" alt="Screenshot 2022-10-29 at 11 23 38" src="https://user-images.githubusercontent.com/82657928/198824659-13c6c83d-3788-421b-89f1-4ea9680ab113.png">

After (pb-4)
<img width="519" alt="Screenshot 2022-10-29 at 11 23 10" src="https://user-images.githubusercontent.com/82657928/198824680-75bab2d0-3b6e-4e0c-a9cf-e0ed61451c21.png">

![features tsx](https://user-images.githubusercontent.com/82657928/198867751-97fc731f-622a-4689-b91a-014d6bda8fe4.png)

Heading
Before (pt-20, mt-20)
<img width="502" alt="Screenshot 2022-10-29 at 11 33 33" src="https://user-images.githubusercontent.com/82657928/198824731-42bfac9b-4c4e-4e0f-872f-23504db270d5.png">

After  (pt-10, mt-10)
<img width="502" alt="Screenshot 2022-10-29 at 11 33 14" src="https://user-images.githubusercontent.com/82657928/198824753-6b1b047f-9de7-48ff-aafb-28a393509f35.png">

![paddingTitle](https://user-images.githubusercontent.com/82657928/198867736-d06b8e30-0e30-467f-9aaf-cf128b734f88.png)

<!-- Add screenshots if applicable -->
